### PR TITLE
fix: reload on blog heading id click

### DIFF
--- a/components/mdx/heading/Heading.tsx
+++ b/components/mdx/heading/Heading.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import cn from "classnames";
 import slugify from "slugify";
+import Link from "next/link";
 
 import Clip from "public/svg/link.svg";
 import type { HeadingVariant } from "types";
@@ -18,11 +19,13 @@ export const Heading = memo<HeadingProps>(({ level: Tag, slug, url }) => {
 
   return (
     <Tag id={id} className={cn(styles.heading, styles[Tag])}>
-      <a id={id} href={`${url}#${id}`} aria-hidden="true" tabIndex={-1} className={styles.link}>
-        <span className={styles.clip}>
-          <Clip />
-        </span>
-      </a>
+      <Link href={`#${id}`} passHref>
+        <a id={id} aria-hidden="true" tabIndex={-1} className={styles.link}>
+          <span className={styles.clip}>
+            <Clip />
+          </span>
+        </a>
+      </Link>
       {slug}
     </Tag>
   );


### PR DESCRIPTION
The old way was refreshing the page when clicking on heading link which was causing a little jagged feeling. Now, that doesn't happen.
There might be a reason you didn't do it before, so if that's the case, you can ignore this and I'd love to know why 😄.
**After**:
![After](https://user-images.githubusercontent.com/41034356/156934344-88c4c1e1-a7fa-4f33-b995-ed080ae5f48d.gif)

